### PR TITLE
Add '-Force' flag onto Move-Item command to cater for same packages being referenced in multiple crawlers

### DIFF
--- a/Install-Packages.ps1
+++ b/Install-Packages.ps1
@@ -49,7 +49,7 @@ $packages | ForEach-Object {
 # Flatten all dlls from all packages into root folder
 
 Push-Location $outputDir
-Get-ChildItem *.dll -Recurse | Move-Item -Destination .
+Get-ChildItem *.dll -Recurse | Move-Item -Destination . -Force
 Get-ChildItem -Directory | Remove-Item -Force -Recurse
 Write-Output "List of files in the $outputDir folder"
 Get-ChildItem


### PR DESCRIPTION
This will remedy Docker image not building because of multiple crawlers referencing same packages
![image](https://user-images.githubusercontent.com/21309610/66922269-046aa700-f027-11e9-90be-f2b59681f07b.png)
