### PR TITLE
Feat(dotnet): Use dotnet cli patterns for restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG VERSION=3.1
-FROM mcr.microsoft.com/dotnet/core/sdk:${VERSION}
+ARG VERSION=1903
+ARG TYPE=nanoserver
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.201-${TYPE}-${VERSION}
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=1903
+ARG VERSION=1809
 ARG TYPE=nanoserver
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.201-${TYPE}-${VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-ARG VERSION=1803
-ARG TYPE=windowsservercore
-FROM mcr.microsoft.com/powershell:6.2.3-${TYPE}-${VERSION}
+ARG VERSION=3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:${VERSION}
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
-
-RUN Invoke-WebRequest -OutFile /nuget.exe -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
 
 WORKDIR /scripts
 
-COPY Install-Packages.ps1 .
+COPY install-packages.ps1 .

--- a/Install-Packages.ps1
+++ b/Install-Packages.ps1
@@ -14,27 +14,34 @@ param(
 $resolvedPackagePath = Resolve-Path $PackageListFile
 $packages = Get-Content ($resolvedPackagePath.Path) | 
     ForEach-Object {
-        $id,$version = $_ -split ' '
+        $id,$version = $_ -split ' '        
+        if(!$version) {            
+            Write-Warrning "No version found for package $id. Using latest release version instead."
+            # TODO: When *-* is supported change to default version
+            $version = '*'
+        }
         [PSCustomObject]@{
             Id = $id
             Version = $version
         }
     }
 
+
+
 # Configure NuGet
 $resolvedNugetPath = Resolve-Path $NugetConfig
 if($FeedNames -And $Key){
     $FeedNames | ForEach-Object {
-        dotnet nuget update source $_ -u $UserName -p $Key -configfile $resolvedNugetPath
+        dotnet nuget update source $_ -u $UserName -p $Key --configfile $resolvedNugetPath
     }
 }
 
 # Dotnet restore
 $projectName = "Project$([Guid]::NewGuid().ToString("N"))"
 $projectPath = Join-Path $PSScriptRoot $projectName
-# We could use the dotnet cli but... it's slow
-# We could use System.Xml but we're doing some basic things
-# Just use here-strings
+# We could use the dotnet cli but... it's slow.
+# We could use System.Xml but we're doing some basic things.
+# Just use here-strings.
 $projectContents = @"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ strategy:
   maxParallel: 2
   matrix:
     Win2019:
-      windowsBaseTag: '1903'
+      windowsBaseTag: '1809'
       pool: 'windows-2019'
 pool:
   vmImage: '$(pool)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,10 +26,11 @@ steps:
 
 - task: Docker@2
   displayName: "Push image"
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   inputs:
     containerRegistry: 'Docker Hub'
     repository: cluedin/nuget-installer
     command: push
     tags: |
       $(windowsBaseTag)-$(Build.BuildId)    
-      $(windowsBaseTag)-latest
+      $(windowsBaseTag)-latest  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ strategy:
   maxParallel: 2
   matrix:
     Win2019:
-      windowsBaseTag: '1809'
+      windowsBaseTag: '1903'
       pool: 'windows-2019'
 pool:
   vmImage: '$(pool)'


### PR DESCRIPTION
BREAKING: This requires packages.txt to be updated with version numbers.
Version numbers may be listed as a full version string, or floating version.
See: https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#floating-versions for details.

A correct packages.txt will have one line per package, with a single space between the package name and the version.
For example:
```
CluedIn.Crawling.GN.Product_SKU 0.1.0-*
CluedIn.Crawling.GN.Product_SKU.Core 0.1.0-*
CluedIn.Crawling.GN.Product_SKU.Infrastructure 0.1.0-*
CluedIn.Crawling.GN.POSExchange 0.1.0-*
CluedIn.ContentExtraction.Aspose 0.1.0-*
SharpZipLib 1.2.0
Microsoft.Exchange.WebServices 2.2.0
```

> A side effect of this implementation - Transitive restore is now supported as the graph is consumed in one hit.
> However there may still be issues in copying assets that are in the parent process or already in place.