### PR TITLE
Add missing assets to copy to be able to install WinSCP package

### DIFF
--- a/Install-Packages.ps1
+++ b/Install-Packages.ps1
@@ -79,7 +79,9 @@ Get-ChildItem *\lib\net40\*.dll -Recurse | Move-Item -Destination . -ErrorAction
 Get-ChildItem *\lib\net35\*.dll -Recurse | Move-Item -Destination . -ErrorAction SilentlyContinue
 Get-ChildItem *\lib\net20\*.dll -Recurse | Move-Item -Destination . -ErrorAction SilentlyContinue
 Get-ChildItem *\lib\net11\*.dll -Recurse | Move-Item -Destination . -ErrorAction SilentlyContinue
+Get-ChildItem *\tools\*.exe -Recurse | Move-Item -Destination . -ErrorAction SilentlyContinue
 Get-ChildItem *.dll -Recurse | Move-Item -Destination . -ErrorAction SilentlyContinue
+Get-ChildItem *.exe -Recurse | Move-Item -Destination . -ErrorAction SilentlyContinue
 Get-ChildItem -Directory | Remove-Item -Force -Recurse
 Write-Output "List of files in the $outputDir folder"
 Get-ChildItem


### PR DESCRIPTION
Exe file from tools folder needs to be copied.

```
.\WinSCP.5.17.10
.\WinSCP.5.17.10\.signature.p7s
.\WinSCP.5.17.10\build
.\WinSCP.5.17.10\lib
.\WinSCP.5.17.10\tools
.\WinSCP.5.17.10\WinSCP.5.17.10.nupkg
.\WinSCP.5.17.10\winscp64.png
.\WinSCP.5.17.10\build\WinSCP.targets
.\WinSCP.5.17.10\lib\net40
.\WinSCP.5.17.10\lib\netstandard2.0
.\WinSCP.5.17.10\lib\net40\WinSCPnet.dll
.\WinSCP.5.17.10\lib\netstandard2.0\WinSCPnet.dll
.\WinSCP.5.17.10\tools\WinSCP.exe
```

